### PR TITLE
Skip rendering in wrap-responder when :render is nil

### DIFF
--- a/src/clojurewerkz/gizmo/responder.clj
+++ b/src/clojurewerkz/gizmo/responder.clj
@@ -48,6 +48,12 @@
   [handler]
   (fn [env]
     (let [handler-env  (handler env)
-          complete-env (hash-utils/deep-merge env handler-env)]
-      (println "Handling uri: " (:uri env) " Rendering: " (:render complete-env))
-      (respond-with complete-env))))
+          complete-env (hash-utils/deep-merge env handler-env)
+          render (:render complete-env)]
+      (if render
+        (do
+          (println "Handling uri: " (:uri env) " Rendering: " (:render complete-env))
+          (respond-with complete-env))
+        (do
+          (println "Handling uri: " (:uri env) " :render not set, rendering skipped.")
+          handler-env)))))

--- a/test/clojurewerkz/gizmo/responder_test.clj
+++ b/test/clojurewerkz/gizmo/responder_test.clj
@@ -52,12 +52,18 @@
                    {:response-hash {:response :hash}
                     :status 201
                     :render :json}))
+        plain-ring-response {:status 404
+                             :body "Not found."}
+        plain-ring-handler (wrap-responder
+                            (fn [e] plain-ring-response))
         res     (handler {:env :env})]
     (testing "Handler receives env from middleware"
       (is (= {:env :env} @env)))
     (testing "Response depends on outcome of handler"
       (is (= 201 (:status res)))
-      (is (= "{\"response\":\"hash\"}" (:body res))))))
+      (is (= "{\"response\":\"hash\"}" (:body res))))
+    (testing "Handler responses without :render key are returned directly"
+      (is (= plain-ring-response (plain-ring-handler nil))))))
 
 (deftest respond-with-html-with-request
   (deflayout respond-with-html-layout "templates/layouts/application.html" [])


### PR DESCRIPTION
To increase compatibility with plain old ring handlers (e.g. compojure's not-found),
return response hash directly instead of calling respond-with when the environment
does not contain a :render entry.
