### PR TITLE
defservice-test-2 was used twice defservice-test-3 not at all

### DIFF
--- a/test/clojurewerkz/gizmo/service_test.clj
+++ b/test/clojurewerkz/gizmo/service_test.clj
@@ -23,12 +23,12 @@
 
 (deftest defservice-is-alive-with-long-running
   (let [res (atom nil)]
-    (defservice defservice-test-2
+    (defservice defservice-test-3
       :config nil
       :start (fn [cfg] (Thread/sleep 100)))
-    (start! defservice-test-2)
+    (start! defservice-test-3)
     (Thread/sleep 10)
-    (is (alive? defservice-test-2))
+    (is (alive? defservice-test-3))
     (is (= nil @res))))
 
 (deftest defservice-stop-test


### PR DESCRIPTION
`defservice-test-2` was used in two tests. In the test after `defservice-test-4` was used, so I guess that was just an oversight. I've renamed it to `defservice-test-3`.
