### PR TITLE
Support the Ring Cookies middleware

### DIFF
--- a/src/clojurewerkz/gizmo/responder.clj
+++ b/src/clojurewerkz/gizmo/responder.clj
@@ -33,7 +33,8 @@
                      {"content-type"  "application/json; charset=utf-8"
                       "content-length" (str (count response))})
      :status (or (:status env) 200)
-     :body response}))
+     :body response
+     :cookies (:cookies env)}))
 
 (defmethod respond-with :resource
   [{:keys [path]}]
@@ -42,7 +43,7 @@
     (ring-response/url-response resource)))
 
 (defmethod respond-with :html
-  [{:keys [widgets status headers layout] :as env}]
+  [{:keys [widgets status headers layout cookies] :as env}]
   (assert (> (count (widget/all-layouts)) 0) "Can't respond with :html without layouts given")
   (let [layout-template (if layout
                           (get (widget/all-layouts) layout)
@@ -57,7 +58,8 @@
                      {"content-type"  "text/html; charset=utf-8"
                       "content-length" (str (count response))})
      :status (or status 200)
-     :body response}))
+     :body response
+     :cookies cookies}))
 
 (defn wrap-responder
   "Responder middleware, shuold be always inserted as a last middleware after routing/handler."

--- a/test/clojurewerkz/gizmo/responder_test.clj
+++ b/test/clojurewerkz/gizmo/responder_test.clj
@@ -44,6 +44,14 @@
                            :response-hash {:response :hash}})]
     (is (= 404 (:status res)))))
 
+(deftest respond-with-cookies
+  (let [cookies {"theCookie" {}}
+        res (respond-with {:render :json
+                           :status 404
+                           :response-hash {:response :hash}
+                           :cookies cookies})]
+    (is (= cookies (:cookies res)))))
+
 (deftest wrap-responder-test
   (let [env     (atom nil)
         handler (wrap-responder


### PR DESCRIPTION
The official ring cookies middleware expects a `cookies` map on the
response object. Gizmo should support a set of standard middleware
like cookies and potentially session and others.

See https://ring-clojure.github.io/ring/ring.middleware.cookies.html