### PR TITLE
Responder echoes request environment

### DIFF
--- a/src/clojurewerkz/gizmo/responder.clj
+++ b/src/clojurewerkz/gizmo/responder.clj
@@ -34,7 +34,7 @@
                       "content-length" (str (count response))})
      :status (or (:status env) 200)
      :body response
-     :cookies (:cookies env)}))
+     :cookies (or (:cookies env) {})}))
 
 (defmethod respond-with :resource
   [{:keys [path]}]
@@ -59,12 +59,11 @@
                       "content-length" (str (count response))})
      :status (or status 200)
      :body response
-     :cookies cookies}))
+     :cookies (or cookies {})}))
 
 (defn wrap-responder
   "Responder middleware, shuold be always inserted as a last middleware after routing/handler."
   [handler]
   (fn [env]
-    (let [handler-env  (handler env)
-          complete-env (hash-utils/deep-merge env handler-env)]
-      (respond-with complete-env))))
+    (let [handler-env  (handler env)]
+      (respond-with handler-env))))

--- a/test/clojurewerkz/gizmo/responder_test.clj
+++ b/test/clojurewerkz/gizmo/responder_test.clj
@@ -60,11 +60,13 @@
                    {:response-hash {:response :hash}
                     :status 201
                     :render :json}))
-        res     (handler {:env :env})]
+        res     (handler {:env :env
+                          :cookies {:foo "bar"}})]
     (testing "Handler receives env from middleware"
-      (is (= {:env :env} @env)))
+      (is (= {:env :env :cookies {:foo "bar"}} @env)))
     (testing "Response depends on outcome of handler"
       (is (= 201 (:status res)))
+      (is (= {} (:cookies res)))
       (is (= "{\"response\":\"hash\"}" (:body res))))))
 
 (deftest respond-with-html-with-request


### PR DESCRIPTION
The responder echoes request environments by merging the
incoming environment with the environment created by handlers.
This results in an echo, i.e. request information is echoed back
to the client as part of the response. This issue arises for
any environment manipulating middleware, e.g. the ring cookie
middleware.