### PR TITLE
Redirect responses require dedicated renderer

### DIFF
--- a/src/clojurewerkz/gizmo/responder.clj
+++ b/src/clojurewerkz/gizmo/responder.clj
@@ -61,6 +61,16 @@
      :body response
      :cookies (or cookies {})}))
 
+(defmethod respond-with :redirect
+  [env]
+  {:status (or (:status env) 302)
+   :body ""
+   :cookies (or (:cookies env) {})
+   :headers (assoc
+              (or (:headers env) {})
+              "Location"
+              (:location env))})
+
 (defn wrap-responder
   "Responder middleware, shuold be always inserted as a last middleware after routing/handler."
   [handler]

--- a/test/clojurewerkz/gizmo/responder_test.clj
+++ b/test/clojurewerkz/gizmo/responder_test.clj
@@ -96,6 +96,16 @@
 </html>" (:body res)))
     (is (= 200 (get-in res [:status])))))
 
+(deftest respond-with-redirect
+  (let [location "http://example.com"
+        accept "application/json"
+        res (respond-with {:render :redirect
+                           :location location
+                           :headers {"Accept" accept}})]
+    (is (= location (get-in res [:headers "Location"])))
+    (is (= accept (get-in res [:headers "Accept"])))
+    (is (= 302 (:status res)))))
+
 (deftest custom-responder
   (defmethod respond-with :whatev
     [env]


### PR DESCRIPTION
A redirect (no matter whether temporary or permanent) does not fall
into any of existing renderer categories. While `:nothing` could be
used, it does exactly do that: Nothing.

Redirect rendering can be added to make the definition of redirect
responses easy.
